### PR TITLE
Add build.propertes, declaring sbt.version 0.13.8.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8


### PR DESCRIPTION
It's much safer to always declare what version of sbt the build is defined for.
