### PR TITLE
Completely squelch com.jcabi.github.Issue$Smart logging

### DIFF
--- a/src/main/scala/com/getbootstrap/no_carrier/Main.scala
+++ b/src/main/scala/com/getbootstrap/no_carrier/Main.scala
@@ -98,17 +98,17 @@ object Main extends App with StrictLogging {
   }
 
   def squelchExcessiveLogging() {
-    import org.slf4j.LoggerFactory
-    import ch.qos.logback.classic.{Logger,Level}
+    import ch.qos.logback.classic.Level
 
     val loggersToSquelch = Set(
       "com.jcabi.aspects.aj.NamedThreads",
-      "com.jcabi.github.Issue$Smart",
       "com.jcabi.http.request.BaseRequest",
       "com.jcabi.manifests.Manifests"
     )
     for { loggerName <- loggersToSquelch } {
-      LoggerFactory.getLogger(loggerName).asInstanceOf[Logger].setLevel(Level.WARN)
+      loggerName.logger.setLevel(Level.WARN)
     }
+
+    "com.jcabi.github.Issue$Smart".logger.setLevel(Level.OFF)
   }
 }

--- a/src/main/scala/com/getbootstrap/no_carrier/util/package.scala
+++ b/src/main/scala/com/getbootstrap/no_carrier/util/package.scala
@@ -27,4 +27,11 @@ package object util {
       }
     }
   }
+
+  implicit class LoggerName(name: String) {
+    import ch.qos.logback.classic.Logger
+    import org.slf4j.LoggerFactory
+
+    def logger: Logger = LoggerFactory.getLogger(name).asInstanceOf[Logger]
+  }
 }


### PR DESCRIPTION
It logs some fairly normal occurrences at the ERROR level. E.g.

```
2015-08-06 04:47:13,130 [ERROR] com.jcabi.github.Issue$Smart - #latestEvent('closed'): thrown java.lang.IllegalStateException(event of type 'closed' not found in issue #16797) out of com.jcabi.github.Issue$Smart#latestEvent_aroundBody40[391] in 2s
```
