### PR TITLE
Allow . to be used in repository names

### DIFF
--- a/src/main/scala/com/getbootstrap/no_carrier/github/util/RepositoryId.scala
+++ b/src/main/scala/com/getbootstrap/no_carrier/github/util/RepositoryId.scala
@@ -3,7 +3,7 @@ package com.getbootstrap.no_carrier.github.util
 import com.jcabi.github.Coordinates.{Simple=>RepoId}
 
 object RepositoryId {
-  private val OwnerSlashRepo = "([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)".r
+  private val OwnerSlashRepo = "([a-zA-Z0-9_-]+)/([a-zA-Z0-9._-]+)".r
 
   def unapply(ownerRepo: String): Option[RepoId] = {
     ownerRepo match {


### PR DESCRIPTION
This fixes a bug where repositories with periods in their names are not recognized by NO CARRIER, even though they are valid.